### PR TITLE
login(role, password) added for the purpose of logging in incorrectly…

### DIFF
--- a/src/test/java/com/Cybertek/Library/Pages/LoginPage.java
+++ b/src/test/java/com/Cybertek/Library/Pages/LoginPage.java
@@ -1,6 +1,7 @@
 package com.Cybertek.Library.Pages;
 
 import com.Cybertek.Library.Utilities.ConfigurationReader;
+import com.Cybertek.Library.Utilities.Driver;
 import org.openqa.selenium.Keys;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -34,9 +35,38 @@ public class LoginPage extends BasePage{
 
 
 
+    /*
+     role = librarian , student, or a random name to login with
+     invalidPassword = enter a invalid password.
+             This method is overloaded for the intentions of NOT logging in.
+             If you wish to login this way you can call from
+                        ConfigurationReader.getProperty("password.librarian || password.student")
+                        and you will successfully login if this is passed in the invalidAccountPassword
+                        otherwise, just use login(String role).
+
+     */
+    public void login(String role, String invalidAccountPassword) {
+
+        String user = "";
+        String password = "";
 
 
+        if(role.equalsIgnoreCase("librarian")|| role.equalsIgnoreCase("student")){
+            if(role.equalsIgnoreCase("librarian")){
+                user = ConfigurationReader.getProperty("username.librarian");
+                password = invalidAccountPassword;
+            }else if(role.equalsIgnoreCase("student")){
+                user = ConfigurationReader.getProperty("username.student");
+                password = invalidAccountPassword;
+            }
+        }else{
+            user = role;
+            password = invalidAccountPassword;
+        }
 
+        userNameInputBox.sendKeys(user);
+        passwordInputBox.sendKeys(password, Keys.ENTER);
+    }
 
 
 


### PR DESCRIPTION
…, You may pass the correct password from ConfigurationReader.getProperty() if you wish to login correctly this way.  This overloaded method was added just for the purpose of logging in incorrectly but is modified to login if the tester wants to login this way.